### PR TITLE
/speakersは配列を返してくるはずなので修正した

### DIFF
--- a/src/types/Other.ts
+++ b/src/types/Other.ts
@@ -19,7 +19,7 @@ export type SpeakerData = {
         name: string
         id: number
     }[]
-}
+}[]
 
 export type SpeakerInfo = {
     policy: string


### PR DESCRIPTION
タイトルのとおりです。
/speakersは配列をJSONにしたものを返してくれるはずなのですがSpeakerDataは配列ではないので不整合が生じてしまいますので修正しました

参考のドキュメントです
https://voicevox.github.io/voicevox_engine/api/#tag/%E3%81%9D%E3%81%AE%E4%BB%96/operation/speakers_speakers_get

初めてのプルリクエストなので至らない点などあると思いますがよろしくお願いします